### PR TITLE
disable lifecycle block

### DIFF
--- a/acl_data_ingest_monitor.tf
+++ b/acl_data_ingest_monitor.tf
@@ -96,14 +96,14 @@ resource "aws_lambda_function" "acl_data_ingest_monitor" {
     Name = "lambda-${var.acl_monitor_name}-${var.naming_suffix}"
   }
 
-  lifecycle {
-    ignore_changes = [
-      filename,
-      last_modified,
-      runtime,
-      source_code_hash,
-    ]
-  }
+  #lifecycle {
+  #  ignore_changes = [
+  #    filename,
+  #    last_modified,
+  #    runtime,
+  #    source_code_hash,
+  #  ]
+  #}
 
 }
 

--- a/nats_data_ingest_monitor.tf
+++ b/nats_data_ingest_monitor.tf
@@ -97,14 +97,14 @@ resource "aws_lambda_function" "nats_data_ingest_monitor" {
     Name = "lambda-${var.nats_monitor_name}-${var.naming_suffix}"
   }
 
-  lifecycle {
-    ignore_changes = [
-      filename,
-      last_modified,
-      runtime,
-      source_code_hash,
-    ]
-  }
+  #lifecycle {
+  #  ignore_changes = [
+  #    filename,
+  #    last_modified,
+  #    runtime,
+  #    source_code_hash,
+  #  ]
+  #}
 
 }
 

--- a/oag_data_ingest_monitor.tf
+++ b/oag_data_ingest_monitor.tf
@@ -96,14 +96,14 @@ resource "aws_lambda_function" "oag_data_ingest_monitor" {
     Name = "lambda-${var.oag_monitor_name}-${var.naming_suffix}"
   }
 
-  lifecycle {
-    ignore_changes = [
-      filename,
-      last_modified,
-      runtime,
-      source_code_hash,
-    ]
-  }
+  #lifecycle {
+  #  ignore_changes = [
+  #    filename,
+  #    last_modified,
+  #    runtime,
+  #    source_code_hash,
+  #  ]
+  #}
 
 }
 


### PR DESCRIPTION
Disabled lifecycle block to deploy lambda python runtime upgrade version 3.11 into PROD. This change was deployed into NOTPROD under YEL-11416 and its valuated execution.